### PR TITLE
Update _SiteFooter.scss

### DIFF
--- a/Packages/Sites/Konglomerat.Website/Resources/Private/Scss/Organisms/_SiteFooter.scss
+++ b/Packages/Sites/Konglomerat.Website/Resources/Private/Scss/Organisms/_SiteFooter.scss
@@ -7,7 +7,7 @@
 	transition-duration: 250ms;
 
 	.site-footer__content {
-		position: relative;
+		position: absolute;
 		max-width: 1200px;
 		width: 100%;
 		margin: 0 auto;


### PR DESCRIPTION

![Bildschirmfoto 2020-09-16 um 13 40 51](https://user-images.githubusercontent.com/10586572/93332654-70025900-f822-11ea-987f-7c08cc4e5b0e.png)
Can you see the transparent stripe on the bottom of the browser window?

This fix does:
- fixes transparent stripe on bottom of page